### PR TITLE
iscomplex should be initialized

### DIFF
--- a/unsupported/Eigen/src/SparseExtra/MarketIO.h
+++ b/unsupported/Eigen/src/SparseExtra/MarketIO.h
@@ -110,6 +110,7 @@ inline bool getMarketHeader(const std::string& filename, int& sym, bool& iscompl
 {
   sym = 0; 
   isvector = false;
+  iscomplex= false;
   std::ifstream in(filename.c_str(),std::ios::in);
   if(!in)
     return false;


### PR DESCRIPTION
Iscomplex in GetMarketHeader should be initialised to false, otherwise the code may not work, in particular if you activate optimization.
