### PR TITLE
cmake: Support disabling test when including eigen as sub-project

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -431,8 +431,17 @@ add_subdirectory(Eigen)
 
 add_subdirectory(doc EXCLUDE_FROM_ALL)
 
-option(BUILD_TESTING "Enable creation of Eigen tests." ON)
-if(BUILD_TESTING)
+# Setting the variable EIGEN_BUILD_TESTING allows to enable/disable
+# the tests independently of the BUILD_TESTING option.
+if(NOT DEFINED EIGEN_BUILD_TESTING)
+  option(BUILD_TESTING "Enable creation of Eigen tests." ON)
+endif()
+if("x${EIGEN_BUILD_TESTING}" STREQUAL "x")
+  # If EIGEN_BUILD_TESTING is not already set, it is set with
+  # the value of BUILD_TESTING
+  set(EIGEN_BUILD_TESTING ${BUILD_TESTING})
+endif()
+if(EIGEN_BUILD_TESTING)
   include(EigenConfigureTesting)
 
   if(EIGEN_LEAVE_TEST_IN_ALL_TARGET)
@@ -482,7 +491,7 @@ endif(NOT WIN32)
 
 configure_file(scripts/cdashtesting.cmake.in cdashtesting.cmake @ONLY)
 
-if(BUILD_TESTING)
+if(EIGEN_BUILD_TESTING)
   ei_testing_print_summary()
 endif()
 

--- a/blas/CMakeLists.txt
+++ b/blas/CMakeLists.txt
@@ -45,7 +45,7 @@ install(TARGETS eigen_blas eigen_blas_static
 
 if(EIGEN_Fortran_COMPILER_WORKS)
 
-if(BUILD_TESTING)
+if(EIGEN_BUILD_TESTING)
   if(EIGEN_LEAVE_TEST_IN_ALL_TARGET)
     add_subdirectory(testing) # can't do EXCLUDE_FROM_ALL here, breaks CTest
   else()

--- a/unsupported/CMakeLists.txt
+++ b/unsupported/CMakeLists.txt
@@ -1,6 +1,6 @@
 add_subdirectory(Eigen)
 add_subdirectory(doc EXCLUDE_FROM_ALL)
-if(BUILD_TESTING)
+if(EIGEN_BUILD_TESTING)
   if(EIGEN_LEAVE_TEST_IN_ALL_TARGET)
     add_subdirectory(test) # can't do EXCLUDE_FROM_ALL here, breaks CTest
   else()


### PR DESCRIPTION
This commit does not change the existing behavior of the build-system, it
only make it possible to explicitly disable Eigen tests in a project including
Eigen as sub-project and already having their own `BUILD_TESTING` option.

This changes allows the following project to have the `BUILD_TESTING` option
set to `ON` while disabling eigen test:

```
/tmp/test/CMakeLists.txt

  cmake_minimum_required(VERSION 3.12)
  project(test)

  include(CTest) # This defines BUILD_TESTING option set to ON by default

  set(EIGEN_BUILD_TESTING 0)
  add_subdirectory(eigen-git-mirror)  # eigen-git-mirror is added as a Git submodule
```