### PR TITLE
BUG: Xcode 11.0 with default -macosx-version-min=10.15 seg faults

### DIFF
--- a/Eigen/src/Core/arch/AVX/PacketMath.h
+++ b/Eigen/src/Core/arch/AVX/PacketMath.h
@@ -14,6 +14,15 @@ namespace Eigen {
 
 namespace internal {
 
+//NOTE: Confirmed failure in XCode 11.0, and ambiguous reports for 11.1 without means of testing
+#if defined(EIGEN_COMP_CLANG) && (EIGEN_COMP_CLANG >= 1100 || EIGEN_COMP_CLANG <= 9999 ) && ( __MAC_OS_X_VERSION_MIN_REQUIRED == 101500 )
+// A nasty bug in the clang compiler shipped with xcode in a common compilation situation
+// when XCode 11.[0-?].[0-?].? and Mac deployment target macOS 10.15 is https://trac.macports.org/ticket/58776#no1
+  #error "There is a nasty bug with -macosx-version-min=10.15, use of AVX instructions, and Xcode 11.0.0 compiler."
+  // NOTE using -macosx-version-min=10.15 with Xcode 11.0.0.?? results in segmentation faults
+  // NOTE using -macosx-version-min=10.14 seems to work perfectly fine for tests
+#endif
+
 #ifndef EIGEN_CACHEFRIENDLY_PRODUCT_THRESHOLD
 #define EIGEN_CACHEFRIENDLY_PRODUCT_THRESHOLD 8
 #endif


### PR DESCRIPTION
Confirmed failure in XCode 11.0 for AVX instructions, and ambiguous
reports for fixes with XCode 11.1 without means of testing.

A nasty bug in the clang compiler shipped with xcode in a common compilation situation
when XCode 11.[0-?].[0-?].? and default -macosx-version-min=10.15.

Reports at https://trac.macports.org/ticket/58776#no1 are consistent with building
eigen with '-macosx-version-min=10.15 -march=corei7-avx' under XCode 11.0.

NOTE: Setting CMAKE_OSX_DEPLOYMENT_TARGET=10.14 (i.e. -macosx-version-min=10.14 -march=corei7-avx)
      is confirmed to allow testing to complete successfully.