### PR TITLE
Add vcpkg installation instructions

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -33,3 +33,17 @@ The "make install" step may require administrator privileges.
 You can adjust the installation destination (the "prefix")
 by passing the -DCMAKE_INSTALL_PREFIX=myprefix option to cmake, as is
 explained in the message that cmake prints at the end.
+
+Method 3. Installing using vcpkg
+********************************
+
+You can download and install eigen using the vcpkg(https://github.com/Microsoft/vcpkg) dependency manager:
+   
+  git clone https://github.com/Microsoft/vcpkg.git
+  cd vcpkg
+  ./bootstrap-vcpkg.sh
+  ./vcpkg integrate install
+  vcpkg install eigen3
+    
+The eigen port in vcpkg is kept up to date by Microsoft team members and community contributors. If the version is out of date, please create an issue or pull request(https://github.com/Microsoft/vcpkg) on the vcpkg repository.
+


### PR DESCRIPTION
`Eigen `is available as a port in [vcpkg](https://github.com/microsoft/vcpkg), a C++ library manager that simplifies installation for eigen and other project dependencies. Documenting the install process here will help users get started by providing a single set of commands to build eigen, ready to be included in their projects.

We also test whether our library ports build in various configurations (dynamic, static) on various platforms (OSX, Linux, Windows: x86, x64, UWP, ARM) to keep a wide coverage for users.

I'm a maintainer for vcpkg, and [here is what the port script looks like](https://github.com/microsoft/vcpkg/blob/master/ports/eigen3/portfile.cmake). We try to keep the library maintained as close as possible to the original library.